### PR TITLE
PascamelCase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The `:separator` argument can either be a regex, string or character.
 
 * `->PascalCase`
 * `->camelCase`
+* `->PascamelCase` (respects case of the first character)
 * `->SCREAMING_SNAKE_CASE`
 * `->snake_case`
 * `->kebab-case`
@@ -66,6 +67,7 @@ Yeah, and then there are the type-converting functions:
 
 * `->PascalCase{Keyword, String, Symbol}`
 * `->camelCase{Keyword, String, Symbol}`
+* `->PascamelCase-{Keyword, String, Symbol}`
 * `->SCREAMING_SNAKE_CASE_{KEYWORD, STRING, SYMBOL}`
 * `->snake_case_{keyword, string, symbol}`
 * `->kebab-case-{keyword, string, symbol}`

--- a/src/camel_snake_kebab/core.cljc
+++ b/src/camel_snake_kebab/core.cljc
@@ -20,3 +20,4 @@
 (defconversion "snake_case"           clojure.string/lower-case clojure.string/lower-case "_")
 (defconversion "kebab-case"           clojure.string/lower-case clojure.string/lower-case "-")
 (defconversion "HTTP-Header-Case"     camel-snake-kebab.internals.misc/capitalize-http-header camel-snake-kebab.internals.misc/capitalize-http-header "-")
+(defconversion "PascamelCase"         camel-snake-kebab.internals.misc/lower-case-rest clojure.string/capitalize "")

--- a/src/camel_snake_kebab/internals/misc.cljc
+++ b/src/camel_snake_kebab/internals/misc.cljc
@@ -1,6 +1,6 @@
 (ns camel-snake-kebab.internals.misc
   (:require [camel-snake-kebab.internals.string-separator :refer [split generic-separator]]
-            [clojure.string :refer [join upper-case capitalize]]))
+            [clojure.string :refer [join upper-case lower-case capitalize] :as s]))
 
 (defn convert-case [first-fn rest-fn sep s & {:keys [separator]
                                               :or   {separator generic-separator}}]
@@ -13,3 +13,11 @@
 (defn capitalize-http-header [s]
   (or (upper-case-http-headers (upper-case s))
       (capitalize s)))
+
+(defn lower-case-rest
+  "First character remains untouched and rest is lower-cased.
+
+  \"TEST\" => \"Test\"
+  \"tEST\" => \"test\""
+  [s]
+  (s/replace s #"\B." #(lower-case %)))

--- a/test/camel_snake_kebab/core_test.cljc
+++ b/test/camel_snake_kebab/core_test.cljc
@@ -39,6 +39,19 @@
       (doseq [input inputs, format formats, [output function] (zip inputs functions)]
         (is (= (format output) (function (format input)))))))
 
+  (testing "->PascamelCase"
+    (let [inputs ["FooBar"
+                  "fooBar"
+                  "FOO_BAR"
+                  "foo_bar"
+                  "foo-bar"
+                  "Foo_Bar"]]
+      (doseq [input inputs
+              :let [first-letter (str (first input))]]
+        (if (= (clojure.string/upper-case first-letter) first-letter)
+          (is (= (csk/->PascalCase input) (csk/->PascamelCase input)))
+          (is (= (csk/->camelCase input) (csk/->PascamelCase input)))))))
+
   (testing "some of the type converting functions"
     (are [x y] (= x y)
       :FooBar   (csk/->PascalCaseKeyword 'foo-bar)


### PR DESCRIPTION
This pull request proposes additional camel/PascalCase transformation which respects case of the first character.

If string starts with upper case letter -> PascalCase
If string starts with lower case letter -> camelCase

Examples: 

```clojure
(testing "->PascamelCase"
    (is (= (csk/->PascamelCase "FooBar") "FooBar"))
    (is (= (csk/->PascamelCase "fooBar") "fooBar"))
    (is (= (csk/->PascamelCase "FOO_BAR") "FooBar"))
    (is (= (csk/->PascamelCase "fOO_BAR") "fOoBar"))
    (is (= (csk/->PascamelCase "foo_bar") "fooBar"))
    (is (= (csk/->PascamelCase "Foo_bar") "FooBar"))
    (is (= (csk/->PascamelCase "foo-bar") "fooBar"))
    (is (= (csk/->PascamelCase "Foo-bar") "FooBar"))
    (is (= (csk/->PascamelCase "Foo_Bar") "FooBar"))
    (is (= (csk/->PascamelCase "foo_Bar") "fooBar")))
```

I needed such conversion in a project and thought it could be useful for others as well. 

*PascamelCase* is not a de-facto term, it came out of my head and I'm happy if someone suggests a better name.