### PR TITLE
Add `transform-top-keys`

### DIFF
--- a/src/camel_snake_kebab/extras.cljc
+++ b/src/camel_snake_kebab/extras.cljc
@@ -6,3 +6,9 @@
   [t coll]
   (letfn [(transform [[k v]] [(t k) v])]
     (postwalk (fn [x] (if (map? x) (into {} (map transform x)) x)) coll)))
+
+(defn transform-top-keys 
+  "Transforms all first level map keys in coll with t."
+  [t coll]
+  (letfn [(transform [[k v]] [(t k) v])]
+    (if (map? coll) (into {} (map transform coll)) coll)))

--- a/test/camel_snake_kebab/extras_test.cljc
+++ b/test/camel_snake_kebab/extras_test.cljc
@@ -1,6 +1,6 @@
 (ns camel-snake-kebab.extras-test
   (:require [camel-snake-kebab.core :as csk]
-            [camel-snake-kebab.extras :refer [transform-keys]]
+            [camel-snake-kebab.extras :refer [transform-keys transform-top-keys]]
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer-macros [deftest testing is are]])))
 
@@ -13,4 +13,15 @@
     [{:the-author "Dr. Seuss" :the-title "Green Eggs and Ham"}]
     [{'the-Author "Dr. Seuss" "The_Title" "Green Eggs and Ham"}]
     {:total-books 1 :all-books [{:the-author "Dr. Seuss" :the-title "Green Eggs and Ham"}]}
+    {'total_books 1 "allBooks" [{'THE_AUTHOR "Dr. Seuss" "the_Title" "Green Eggs and Ham"}]}))
+
+(deftest transform-top-keys-test
+  (are [x y] (= x (transform-top-keys csk/->kebab-case-keyword y))
+    nil nil
+    {} {}
+    [] []
+    {:total-books 0 :all-books []} {'total_books 0 "allBooks" []}
+    [{'the-Author "Dr. Seuss" "The_Title" "Green Eggs and Ham"}]
+    [{'the-Author "Dr. Seuss" "The_Title" "Green Eggs and Ham"}]
+    {:total-books 1 :all-books [{'THE_AUTHOR "Dr. Seuss" "the_Title" "Green Eggs and Ham"}]}
     {'total_books 1 "allBooks" [{'THE_AUTHOR "Dr. Seuss" "the_Title" "Green Eggs and Ham"}]}))


### PR DESCRIPTION
Make a function that will transform only the top level keys as opposed to recursively doing so.