### PR TITLE
Use best practices in the documentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,32 +1,32 @@
 # Examples
 
 ```clojure
-(use 'camel-snake-kebab.core)
+(require '[camel-snake-kebab.core :as csk])
 
-(->camelCase 'flux-capacitor)
+(csk/->camelCase 'flux-capacitor)
 ; => 'fluxCapacitor
 
-(->SCREAMING_SNAKE_CASE "I am constant")
+(csk/->SCREAMING_SNAKE_CASE "I am constant")
 ; => "I_AM_CONSTANT"
 
-(->kebab-case :object_id)
+(csk/->kebab-case :object_id)
 ; => :object-id
 
-(->HTTP-Header-Case "x-ssl-cipher")
+(csk/->HTTP-Header-Case "x-ssl-cipher")
 ; => "X-SSL-Cipher"
 ```
 
 There are also functions that convert the value type for you:
 
 ```clojure
-(->kebab-case-keyword "object_id")
+(csk/->kebab-case-keyword "object_id")
 ; => :object-id
 ```
 
 If the default way of separating words doesn't work in your use case, you can override it:
 
 ```clojure
-(->snake_case :s3-key :separator \-)
+(csk/->snake_case :s3-key :separator \-)
 ; => :s3_key
 ```
 
@@ -36,37 +36,37 @@ The `:separator` argument can either be a regex, string or character.
 
 1. Add the following to your `project.clj` `:dependencies`:
 
-  ```clojure
-  [camel-snake-kebab "0.4.0"]
-  ```
+```clojure
+[camel-snake-kebab "0.4.0"]
+```
 
 2. Add the following to your namespace declaration:
 
-  ```clojure
-  :require [camel-snake-kebab.core :refer :all]
-  ```
+```clojure
+(:require [camel-snake-kebab.core :as csk])
+```
 
 # Available Conversion Functions
 
-* `->PascalCase`
-* `->camelCase`
-* `->SCREAMING_SNAKE_CASE`
-* `->snake_case`
-* `->kebab-case`
-* `->Camel_Snake_Case`
-* `->HTTP-Header-Case`
+* `csk/->PascalCase`
+* `csk/->camelCase`
+* `csk/->SCREAMING_SNAKE_CASE`
+* `csk/->snake_case`
+* `csk/->kebab-case`
+* `csk/->Camel_Snake_Case`
+* `csk/->HTTP-Header-Case`
 
 You should be able to figure out all what all of them do.
 
 Yeah, and then there are the type-converting functions:
 
-* `->PascalCase{Keyword, String, Symbol}`
-* `->camelCase{Keyword, String, Symbol}`
-* `->SCREAMING_SNAKE_CASE_{KEYWORD, STRING, SYMBOL}`
-* `->snake_case_{keyword, string, symbol}`
-* `->kebab-case-{keyword, string, symbol}`
-* `->Camel_Snake_Case_{Keyword, String, Symbol}`
-* `->HTTP-Header-Case-{Keyword, String, Symbol}`
+* `csk/->PascalCase{Keyword, String, Symbol}`
+* `csk/->camelCase{Keyword, String, Symbol}`
+* `csk/->SCREAMING_SNAKE_CASE_{KEYWORD, STRING, SYMBOL}`
+* `csk/->snake_case_{keyword, string, symbol}`
+* `csk/->kebab-case-{keyword, string, symbol}`
+* `csk/->Camel_Snake_Case_{Keyword, String, Symbol}`
+* `csk/->HTTP-Header-Case-{Keyword, String, Symbol}`
 
 # Notes
 
@@ -79,37 +79,37 @@ Yeah, and then there are the type-converting functions:
 ```clojure
 (require '[clojure.data.json :as json])
 
-(json/read-str "{\"firstName\":\"John\",\"lastName\":\"Smith\"}" :key-fn ->kebab-case-keyword)
+(json/read-str "{\"firstName\":\"John\",\"lastName\":\"Smith\"}" :key-fn csk/->kebab-case-keyword)
 ; => {:first-name "John", :last-name "Smith"}
 
 ; And back:
 
-(json/write-str {:first-name "John", :last-name "Smith"} :key-fn ->camelCaseString)
+(json/write-str {:first-name "John", :last-name "Smith"} :key-fn csk/->camelCaseString)
 ; => "{\"firstName\":\"John\",\"lastName\":\"Smith\"}"
 ```
 
 ## With Plain Maps
 
 ```clojure
-(require '[camel-snake-kebab.extras :refer [transform-keys]])
+(require '[camel-snake-kebab.extras :as cske])
 
-(transform-keys ->kebab-case-keyword {"firstName" "John", "lastName" "Smith"})
+(cske/transform-keys csk/->kebab-case-keyword {"firstName" "John", "lastName" "Smith"})
 ; => {:first-name "John", :last-name "Smith"}
 
 ; And back:
 
-(transform-keys ->camelCaseString {:first-name "John", :last-name "Smith"})
+(cske/transform-keys csk/->camelCaseString {:first-name "John", :last-name "Smith"})
 ; => {"firstName" "John", "lastName" "Smith"}
 ```
 
 ## With JavaBeans
 
 ```clojure
-(require '[camel-snake-kebab.extras :refer [transform-keys]])
+(require '[camel-snake-kebab.extras :as ckse])
 
 (->> (java.util.Date.)
      (bean)
-     (transform-keys ->kebab-case)
+     (cske/transform-keys csk/->kebab-case)
      :timezone-offset)
 ; => -120
 ```
@@ -119,16 +119,16 @@ Yeah, and then there are the type-converting functions:
 If you're going to do case conversion in a hot spot, use [core.memoize](https://github.com/clojure/core.memoize) to avoid doing the same conversions over and over again.
 
 ```clojure
-(use 'clojure.core.memoize)
-(use 'criterium.core)
+(require '[clojure.core.memoize :as m])
+(require '[criterium.core :as cc])
 
 (def memoized->kebab-case
-  (fifo ->kebab-case {} :fifo/threshold 512))
+  (m/fifo csk/->kebab-case {} :fifo/threshold 512))
 
-(quick-bench (->kebab-case "firstName"))
+(cc/quick-bench (csk/->kebab-case "firstName"))
 ; ... Execution time mean : 6,384971 µs ...
 
-(quick-bench (memoized->kebab-case "firstName"))
+(cc/quick-bench (memoized->kebab-case "firstName"))
 ; ... Execution time mean : 700,146806 ns ...
 ```
 


### PR DESCRIPTION
### What ?

Can't remember where I saw it first, about Clojure libraries in the READMEs, the demonstration of the library usage is still using the deprecated `use` instead of `require`.

This PR tries to remedy that for this nifty little library.

### The description of the change

As opposed to using

`(use 'camel-snake-kebab.core)`

use

`(require '[camel-snake-kebab.core :as csk])`

as its the recommended practice for using Clojure libraries.

See the Clojure Style Guide:
https://github.com/bbatsov/clojure-style-guide#prefer-require-over-use

For `camel-snake-kebab.core` I've abbreviated it to `csk`.
And for `camel-snake-kebab.extra` I've used `cske`.

### Notes

I've tried every single function in the document in the REPL.
And I also got bit by the `bean` conversion as per: https://github.com/clj-commons/camel-snake-kebab/issues/50
This is while running the project with the profile `1.9`.

I picked the abbreviations of `csk` & `cske`. But would be quite happy to change them to something else that you might deem suitable.

Let me know what you think, thanks.