### PR TITLE
Handle nil values similar to how Clojure does for #63

### DIFF
--- a/src/camel_snake_kebab/internals/alter_name.cljc
+++ b/src/camel_snake_kebab/internals/alter_name.cljc
@@ -20,4 +20,8 @@
   (alter-name [this f]
     (if (namespace this)
       (throw (ex-info "Namespaced symbols are not supported" {:input this}))
-      (-> this name f symbol))))
+      (-> this name f symbol)))
+
+  nil
+  (alter-name [_ _]
+    nil))

--- a/src/camel_snake_kebab/internals/macros.clj
+++ b/src/camel_snake_kebab/internals/macros.clj
@@ -13,10 +13,13 @@
                  (convert-case (resolve first-fn) (resolve rest-fn) sep)
                  (str "->")
                  (symbol)))]
-    (for [[type-label type-converter] {"string" `identity "symbol" `symbol "keyword" `keyword}]
+    (for [[type-label [type-converter nil-value]] {"string"  [`identity ""]
+                                                   "symbol"  [`symbol nil]
+                                                   "keyword" [`keyword nil]}]
       `(defn ~(make-name type-label) [s# & rest#]
-         {:pre [(not (nil? s#))]}
-         (~type-converter (apply convert-case ~first-fn ~rest-fn ~sep (name s#) rest#))))))
+         (~type-converter (if (some? s#)
+                            (apply convert-case ~first-fn ~rest-fn ~sep (name s#) rest#)
+                            ~nil-value))))))
 
 (defmacro defconversion [case-label first-fn rest-fn sep]
   `(do  ~(type-preserving-function  case-label first-fn rest-fn sep)

--- a/test/camel_snake_kebab/core_test.cljc
+++ b/test/camel_snake_kebab/core_test.cljc
@@ -64,6 +64,7 @@
   (testing "returns idiomatic response for type converting functions on nil input"
     (is (nil? (csk/->kebab-case-keyword nil)))
     (is (= "" (csk/->kebab-case-string nil)))
-    (is (thrown? IllegalArgumentException (csk/->kebab-case-symbol nil))))
+    #?(:clj (is (thrown? IllegalArgumentException (csk/->kebab-case-symbol nil)))
+       :cljs (is (thrown? js/Error (csk/->kebab-case-symbol nil)))))
   (testing "returns idiomatic response for non-type converting functions on nil input"
     (is (nil? (csk/->kebab-case nil)))))

--- a/test/camel_snake_kebab/core_test.cljc
+++ b/test/camel_snake_kebab/core_test.cljc
@@ -59,3 +59,11 @@
     "X-SSL-Cipher"     "x-ssl-cipher"
     "X-WAP-Profile"    "x-wap-profile"
     "X-XSS-Protection" "x-xss-protection"))
+
+(deftest nils-test
+  (testing "returns idiomatic response for type converting functions on nil input"
+    (is (nil? (csk/->kebab-case-keyword nil)))
+    (is (= "" (csk/->kebab-case-string nil)))
+    (is (thrown? IllegalArgumentException (csk/->kebab-case-symbol nil))))
+  (testing "returns idiomatic response for non-type converting functions on nil input"
+    (is (nil? (csk/->kebab-case nil)))))


### PR DESCRIPTION
This _potentially_ addresses #63. The goal is to make the behavior on `nil` the exact same as nil would be handled with Clojure equivalent functions.

The above behavior works like the following:

| CSK                                | CLJ             | Nil input behavior                  |
| ---------------------- | ----------- | --------------------------- |
| `-><case>-keyword` | `keyword` | `nil`                                          |
| `-><case>-string`      | `str`           | `""`                                           |
| `-><case>-symbol`   | `symbol`   | `IllegalArgumentException` |
| `-><case>`                 | `identity`  | `nil`                                          |

I could also see the argument for simply returning `nil` for all of the above instead or if you truly feel `nil` is just a bad input, throwing `IllegalArgumentException`/`NullPointerException` would be fine and still better than an `Error`. Let me know if you prefer one more than the other and I'm happy to adjust the PR.

```clojure
(deftest nils-test
  (testing "returns idiomatic response for type converting functions on nil input"
    (is (nil? (csk/->kebab-case-keyword nil)))
    (is (= "" (csk/->kebab-case-string nil)))
    (is (thrown? IllegalArgumentException (csk/->kebab-case-symbol nil))))
  (testing "returns idiomatic response for non-type converting functions on nil input"
    (is (nil? (csk/->kebab-case nil)))))
```

For reference:

`keyword`

```clojure
user=> (keyword nil)
nil
user=> (keyword "foo")
:foo
user=> (keyword :foo)
:foo
user=> (keyword 'foo)
:foo
```

`symbol`

```clojure
user=> (symbol nil)
Execution error (IllegalArgumentException) at user/eval2101 (REPL:1).
no conversion to symbol

user=> (symbol "foo")
foo
user=> (symbol :foo)
foo
user=> (symbol 'foo)
foo
```

`str`

```clojure
user=> (str nil)
""
user=> (str "foo")
"foo"
user=> (str :foo)
":foo"
user=> (str 'foo)
"foo"
```

`name`

```clojure
user=> (name nil)
Execution error (NullPointerException) at user/eval2091 (REPL:1).
null

user=> (name "foo")
"foo"
user=> (name :foo)
"foo"
user=> (name 'foo)
"foo"
```
