### PR TITLE
Prevent the Null Pointer Exception reported in #65

### DIFF
--- a/src/camel_snake_kebab/internals/misc.cljc
+++ b/src/camel_snake_kebab/internals/misc.cljc
@@ -5,7 +5,8 @@
 (defn convert-case [first-fn rest-fn sep s & {:keys [separator]
                                               :or   {separator generic-separator}}]
   (let [[first & rest] (split separator s)]
-    (join sep (cons (first-fn first) (map rest-fn rest)))))
+    (join sep (cons (if first (first-fn first) "") 
+                    (map rest-fn rest)))))
 
 (def upper-case-http-headers
   #{"CSP" "ATT" "WAP" "IP" "HTTP" "CPU" "DNT" "SSL" "UA" "TE" "WWW" "XSS" "MD5"})


### PR DESCRIPTION
When `first` is nil, there is no point of calling `first-fn`, return empty string instead.