### PR TITLE
Don't throw an AssertionError on nil input

### DIFF
--- a/src/camel_snake_kebab/internals/macros.cljc
+++ b/src/camel_snake_kebab/internals/macros.cljc
@@ -22,7 +22,6 @@
                  (symbol)))]
     (for [[type-label type-converter] {"string" `identity "symbol" `symbol "keyword" `keyword}]
       `(defn ~(make-name type-label) [s# & rest#]
-         {:pre [(not (nil? s#))]}
          (~type-converter (apply convert-case ~first-fn ~rest-fn ~sep (name s#) rest#))))))
 
 (defmacro defconversion [case-label first-fn rest-fn sep]


### PR DESCRIPTION
Preconditions throw an AssertionError if they fail.

Error:s are usually not caught/handled so this can have dire
consequences if an unexpected nil value shows up (see #63).

This reverts commit 4b3d73094dfddf024c9d08eeee684a34b02e1df7.