### PR TITLE
Add Sentence case and Title Case for string output

### DIFF
--- a/src/camel_snake_kebab/core.cljc
+++ b/src/camel_snake_kebab/core.cljc
@@ -13,6 +13,8 @@
   ->snake_case
   ->kebab-case
   ->HTTP-Header-Case
+  ->Sentence
+  ->Title
 
   ->PascalCaseKeyword
   ->camelCaseKeyword
@@ -21,6 +23,8 @@
   ->kebab-case-keyword
   ->Camel_Snake_Case_Keyword
   ->HTTP-Header-Case-Keyword
+  ->Sentencekeyword
+  ->TitleKeyword
 
   ->PascalCaseString
   ->camelCaseString
@@ -29,6 +33,8 @@
   ->kebab-case-string
   ->Camel_Snake_Case_String
   ->HTTP-Header-Case-String
+  ->Sentencestring
+  ->TitleString
 
   ->PascalCaseSymbol
   ->camelCaseSymbol
@@ -36,7 +42,9 @@
   ->snake_case_symbol
   ->kebab-case-symbol
   ->Camel_Snake_Case_Symbol
-  ->HTTP-Header-Case-Symbol)
+  ->HTTP-Header-Case-Symbol
+  ->Sentencesymbol
+  ->Titlesymbol)
 
 (defn convert-case
   "Converts the case of a string according to the rule for the first
@@ -53,3 +61,5 @@
 (defconversion "snake_case"           clojure.string/lower-case clojure.string/lower-case "_")
 (defconversion "kebab-case"           clojure.string/lower-case clojure.string/lower-case "-")
 (defconversion "HTTP-Header-Case"     camel-snake-kebab.internals.misc/capitalize-http-header camel-snake-kebab.internals.misc/capitalize-http-header "-")
+(defconversion "Sentencecase"         clojure.string/capitalize clojure.string/lower-case " ")
+(defconversion "TitleCase"            clojure.string/capitalize clojure.string/capitalize " ")

--- a/src/camel_snake_kebab/internals/macros.cljc
+++ b/src/camel_snake_kebab/internals/macros.cljc
@@ -1,13 +1,17 @@
 (ns ^:no-doc camel-snake-kebab.internals.macros
   #?(:cljs (:refer-clojure :exclude [resolve]))
   (:require [camel-snake-kebab.internals.alter-name :refer [alter-name]]
-            [camel-snake-kebab.internals.misc :refer [convert-case]]))
+            [camel-snake-kebab.internals.misc :refer [convert-case]]
+            [clojure.string]))
 
 #?(:cljs
    (defn resolve [sym]
      ;; On self-hosted ClojureScript, macros are evaluated under the `:cljs` conditional branch
      ;; In that case, we need to use `eval` in order to resolve variables instead of `resolve`
      (eval `(~'var ~sym))))
+
+(defn strip-whitespace [s]
+  (clojure.string/replace s #" " ""))
 
 (defn type-preserving-function [case-label first-fn rest-fn sep]
   `(defn ~(symbol (str "->" case-label)) [s# & rest#]
@@ -19,6 +23,7 @@
             (->> (str case-label " " type-label)
                  (convert-case (resolve first-fn) (resolve rest-fn) sep)
                  (str "->")
+                 (strip-whitespace)
                  (symbol)))]
     (for [[type-label type-converter] {"string" `identity "symbol" `symbol "keyword" `keyword}]
       `(defn ~(make-name type-label) [s# & rest#]


### PR DESCRIPTION
This is for the use-case of formatting a keyword or other symbol into something which you might show to the user in a plain sentence, addressing Feature requests #74 and #37

The main niggle here is that the naming scheme of the functions matches the output, which obviously can't contain a space. I have offered the compromise of stripping spaces from symbol names as they are unusable (though interestingly allowable).

I've also opted for simply "Sentence" and "Title", again for readability so we don't end up with e.g. `->Sentencecasesymbol`. I'd be happy to update based on any feedback.

I haven't tested this on cljs, but I'm pretty sure I haven't added anything problematic there