### PR TITLE
Fix transform-keys clears metadata ( #73 )

### DIFF
--- a/src/camel_snake_kebab/extras.cljc
+++ b/src/camel_snake_kebab/extras.cljc
@@ -5,4 +5,4 @@
   "Recursively transforms all map keys in coll with t."
   [t coll]
   (letfn [(transform [[k v]] [(t k) v])]
-    (postwalk (fn [x] (if (map? x) (into {} (map transform x)) x)) coll)))
+    (postwalk (fn [x] (if (map? x) (with-meta (into {} (map transform x)) (meta x)) x)) coll)))

--- a/test/camel_snake_kebab/extras_test.cljc
+++ b/test/camel_snake_kebab/extras_test.cljc
@@ -14,3 +14,21 @@
     [{'the-Author "Dr. Seuss" "The_Title" "Green Eggs and Ham"}]
     {:total-books 1 :all-books [{:the-author "Dr. Seuss" :the-title "Green Eggs and Ham"}]}
     {'total_books 1 "allBooks" [{'THE_AUTHOR "Dr. Seuss" "the_Title" "Green Eggs and Ham"}]}))
+
+(deftest transform-keys-with-metadata-test
+  (are [x y metadata]
+    (let [y-with-metadata (with-meta y metadata)
+          y-transformed (transform-keys csk/->kebab-case-keyword y-with-metadata)]
+      (and (= x y-transformed)
+           (= metadata (meta y-transformed))))
+    {} {} {:type-name :metadata-type}
+    [] [] {:type-name :check}
+    {:total-books 0 :all-books []} {'total_books 0 "allBooks" []} {:type-name :metadata-type}
+
+    [{:the-author "Dr. Seuss" :the-title "Green Eggs and Ham"}]
+    [{'the-Author "Dr. Seuss" "The_Title" "Green Eggs and Ham"}]
+    {:type-name :metadata-type}
+
+    {:total-books 1 :all-books [{:the-author "Dr. Seuss" :the-title "Green Eggs and Ham"}]}
+    {'total_books 1 "allBooks" [{'THE_AUTHOR "Dr. Seuss" "the_Title" "Green Eggs and Ham"}]}
+    {:type-name :metadata-type}))


### PR DESCRIPTION
Hello. I've found the issue 73 hasn't been resolved yet.

https://github.com/clj-commons/camel-snake-kebab/issues/73

I'm using [lacinia]( https://github.com/walmartlabs/lacinia )(a graphql implementation) and [camel-snake-kebab](https://github.com/clj-commons/camel-snake-kebab) together these days. And I found that when camel-snake-kebab did the case transformations, the metadata that was on the input was lost on the return value.

In lacinia, when using a union type, the types of the objects are recorded in the each object's metadata.
And it passes the types in the metadata to the client.

So I found the issue while researching to fix this issue.

I'm not a native English speaker, so my sentences may read unnaturally. thank you.
