### PR TITLE
ci: Pin setup-clojure action to commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
 
     - name: Install Babashka & Clojure
-      uses: DeLaGuardo/setup-clojure@13.2
+      uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360
       with:
         lein: 'latest'
 


### PR DESCRIPTION
...following the advice on [https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions#using-third-party-actions](https://web.archive.org/web/20250325210845/https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Fixup to c0a3675df193e478d1e73d3ed781557f2414f96c.