### PR TITLE
docs: readme: Remove CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Clojars Project](https://img.shields.io/clojars/v/camel-snake-kebab.svg)](https://clojars.org/camel-snake-kebab)
 [![cljdoc badge](https://cljdoc.org/badge/camel-snake-kebab)](https://cljdoc.org/d/camel-snake-kebab/camel-snake-kebab/CURRENT)
-[![CircleCI](https://circleci.com/gh/clj-commons/camel-snake-kebab.svg?style=svg)](https://circleci.com/gh/clj-commons/camel-snake-kebab)
 [![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://book.babashka.org#badges)
 
 GOTO https://clj-commons.org/camel-snake-kebab/


### PR DESCRIPTION
...now that we use GitHub Actions instead.

Fixup to c0a3675df193e478d1e73d3ed781557f2414f96c.